### PR TITLE
optarg for strict validation

### DIFF
--- a/libs/functions.sh
+++ b/libs/functions.sh
@@ -181,7 +181,9 @@ function testRepository {
 
 	echo
 	echo "Validating the XML:"
-	echo "fails without report are ignored strict wildcard errors"
+	if [ "${TEST_STRICT}" != "true" ]; then
+		echo "fails without report are ignored strict wildcard errors"
+	fi
 	if [ ! -f ${TMP}/OAI-PMH.xsd ]; then
 		curl --silent "http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" -o ${TMP}/OAI-PMH.xsd
 	fi
@@ -190,7 +192,11 @@ function testRepository {
 	# http://blog.gmane.org/gmane.comp.gnome.lib.xml.general/month=20091101/page=2
 	for xml in identify listmetadataformats listsets listrecords listidentifiers; do
 		if [ -s ${TMP}/${xml}.xml ]; then
-			xmllint --noout --schema ${TMP}/OAI-PMH.xsd ${TMP}/${xml}.xml 2>&1| grep -v strict
+			if [ "${TEST_STRICT}" == "true" ]; then
+				xmllint --noout --schema ${TMP}/OAI-PMH.xsd ${TMP}/${xml}.xml 2>&1
+			else
+				xmllint --noout --schema ${TMP}/OAI-PMH.xsd ${TMP}/${xml}.xml 2>&1| grep -v strict
+			fi
 		fi
 	done
 

--- a/oaiharvester
+++ b/oaiharvester
@@ -54,6 +54,7 @@ Options:
   -r, --repository[=id]         Sets the repository identifier to harvest. This corresponds
                                 with the identifier in the config file.
   -t, --test                    Do not harvest, but test if the repository validates.
+      --test-strict				Same as "-t", but not ignoring strict validation errors.
   -v, --version                 Displays the shell-oaiharvester version.
 EOF
 }
@@ -92,6 +93,7 @@ while [[ "$#" -gt 0 ]]; do
 		--quiet|-q) QUIET="true" ;;
 		--no-records|-n) VERB="ListIdentifiers" ;;
 		--test|-t) TEST="true" ;;
+		--test-strict) TEST_STRICT="true" ;;
 		--version|-v) echo "${VERSION}"; exit 0 ;;
 		*) die "$0: Unknown command input" ;;
 	esac
@@ -175,7 +177,7 @@ mkdir -p ${TMP} 2>/dev/null || die "Not able to create temporary workdir: ${TMP}
 
 # Find out if we want to validate only
 # no need for logfile in this step
-if [ "${TEST}" == "true" ]; then
+if [ "${TEST}" == "true" -o "${TEST_STRICT}" == "true" ]; then
 	testRepository
 	exit 0
 fi


### PR DESCRIPTION
When implementing an OAI-PMH repository could be useful to have access to strict schema validation errors that are silenced in the implementation for the `--test` optarg.

This PR adds the `--test-strict` optarg so that those errors become visible.